### PR TITLE
avoid failing if release does not have any assets associated with it

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -18,7 +18,9 @@ def output(release):
     print('::set-output name=release::{}'.format(release.tag_name))
     print('::set-output name=release_id::{}'.format(release.id))
     assets = release.get_assets()
-    print('::set-output name=browser_download_url::{}'.format(assets[0].browser_download_url))
+    dl_url = assets[0].browser_download_url if len(assets) > 0 else '""'
+    print('::set-output name=browser_download_url::{}'.format(dl_url))
+
 
 # Releases parsing
 for release in releases:
@@ -38,4 +40,4 @@ for release in releases:
             output(release)
             break
     else:
-        print('Cant get release')
+        print('Can\'t get release')


### PR DESCRIPTION
Avoid this failure:

```
Run rez0n/actions-github-release@main
/usr/bin/docker run [...]
Traceback (most recent call last):
  File "/entrypoint.py", line 27, in <module>
    output(release)
  File "/entrypoint.py", line 21, in output
    print('::set-output name=browser_download_url::{}'.format(assets[0].browser_download_url))
  File "/usr/local/lib/python3.9/site-packages/github/PaginatedList.py", line 49, in __getitem__
    return self.__elements[index]
IndexError: list index out of range
```

Fixes #6 