### PR TITLE
Fix assets out of bound error still occurring

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -18,7 +18,7 @@ def output(release):
     print('::set-output name=release::{}'.format(release.tag_name))
     print('::set-output name=release_id::{}'.format(release.id))
     assets = release.get_assets()
-    dl_url = assets[0].browser_download_url if len(assets) > 0 else '""'
+    dl_url = assets[0].browser_download_url if assets.totalCount > 0 else '""'
     print('::set-output name=browser_download_url::{}'.format(dl_url))
 
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -18,7 +18,7 @@ def output(release):
     print('::set-output name=release::{}'.format(release.tag_name))
     print('::set-output name=release_id::{}'.format(release.id))
     assets = release.get_assets()
-    dl_url = assets[0].browser_download_url if assets else '""'
+    dl_url = assets[0].browser_download_url if len(assets) > 0 else '""'
     print('::set-output name=browser_download_url::{}'.format(dl_url))
 
 


### PR DESCRIPTION
The error is still occurring for me, the previous fix I think assumed that the `assets` property will be falsey if empty. Unfortunately that is not the case.

I attempted using `len` but the object `PaginatedList` does not support it either, so I'm using `totalCount` which seems to have worked (tested myself).

Relevent issue #9 