### PR TITLE
fix: use fixed version of base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:alpine
+FROM python:3.10.2-alpine3.15
 
 RUN apk --update add build-base libffi-dev
 RUN pip install --no-cache-dir pygithub


### PR DESCRIPTION
The issue fixed in #12 was actually caused by using the `latest` tag of the base Python image.  Since the `latest` tag is mutable, the contents of it changed and that change caused this breakage.  To avoid this kind of unexpected issue, it's a Docker best practice not to use the `latest` tag in a production environment.  

This PR adds an immutable version to the base container, it's the exact same code as `latest` at the moment of PR creation.