### PR TITLE
Replace set-output with environment files

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -16,11 +16,11 @@ releases = repo.get_releases()
 # Output formatting function
 def output(release):
     outfile = open(os.getenv('GITHUB_OUTPUT'), 'w')
-    outfile.write('release={}'.format(release.tag_name))
-    outfile.write('release_id={}'.format(release.id))
+    outfile.write(f'release={release.tag_name}\n')
+    outfile.write(f'release_id={release.id}\n')
     assets = release.get_assets()
     dl_url = assets[0].browser_download_url if assets.totalCount > 0 else '""'
-    outfile.write('browser_download_url={}'.format(dl_url))
+    outfile.write(f'browser_download_url={dl_url}\n')
     outfile.close()
 
 # Releases parsing

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -15,12 +15,13 @@ releases = repo.get_releases()
 
 # Output formatting function
 def output(release):
-    print('::set-output name=release::{}'.format(release.tag_name))
-    print('::set-output name=release_id::{}'.format(release.id))
+    outfile = open(os.getenv('GITHUB_OUTPUT'), 'w')
+    outfile.write('release={}'.format(release.tag_name))
+    outfile.write('release_id={}'.format(release.id))
     assets = release.get_assets()
     dl_url = assets[0].browser_download_url if assets.totalCount > 0 else '""'
-    print('::set-output name=browser_download_url::{}'.format(dl_url))
-
+    outfile.write('browser_download_url={}'.format(dl_url))
+    outfile.close()
 
 # Releases parsing
 for release in releases:


### PR DESCRIPTION
This resolves #17 (deprecation of set-output) by using GitHub Actions [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).  Hopefully @rez0n is safe and healthy and can consider accepting this PR!