### PR TITLE
Add args to action metadata for inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,3 +28,7 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.token }}
+    - ${{ inputs.repository }}
+    - ${{ inputs.type }}


### PR DESCRIPTION
Resolves #22 by adding the `args` property to action.yaml as per the [docs](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file).  I've tested the changes in my fork but it was a private repo so can't share it, happy to try and replicate in a public repo if you want when I get a chance.