### PR TITLE
feat: add `filter` input to match only interesting releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Name | Description | Example
 repository | The Github owner/repository | `nodejs/node`
 type | The release type (prerelease | stable | latest | nodraft) | `stable`
 token | Github auth token (default variable for each action session) | `${{ secrets.GITHUB_TOKEN }}`
+filter | A regex, filtering out releases that do not match | `^.*(?<!\+alpha)$`
 
 #### Possible values for `type` input
 * *stable* - Get the stable `latest` release

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,10 @@ inputs:
   type:
     description: 'Wanted release type (latest, stable, draft, nodraft)'
     required: true
+  filter:
+    description: 'A regex, filtering out releases that do not match'
+    required: false
+    type: string
 
 outputs:
   release:

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -2,11 +2,17 @@
 
 from github import Github
 import os
+import re
 
 # Try to get options from enviroment and from inputs as fallback
 wanted_release = os.getenv('type', os.getenv('INPUT_TYPE'))
 repository = os.getenv('repository', os.getenv('INPUT_REPOSITORY'))
 token = os.getenv('token', os.getenv('INPUT_TOKEN', None))
+
+filter = os.getenv('filter', os.getenv('INPUT_FILTER', None))
+filter_regex = None
+if filter:
+    filter_regex = re.compile(filter)
 
 # Init class
 G = Github(token) if token else Github()
@@ -25,6 +31,9 @@ def output(release):
 
 # Releases parsing
 for release in releases:
+    if filter_regex is not None and re.search(filter_regex, release.tag_name) is None:
+        continue
+
     if wanted_release == 'stable':
         if release.prerelease == 0 and release.draft == 0:
             output(release)


### PR DESCRIPTION
Hey!

In https://github.com/falcosecurity/libs we create two kinds of releases: libs releases and drivers releases.
We use a customized version of this action allowing us to exclude one kind or another. You can see the usage here: https://github.com/falcosecurity/libs/blob/ba1619a2a5a5990a0114b63a3fffe446c0ebc1dc/.github/workflows/release-body.yml#L18-L34

It would be good if we could have the same filtering capability here.
This PR adds a new `filter` input accepting a regex to exclude all releases not matching it.